### PR TITLE
Fixed removing shares from ones bought before the sell

### DIFF
--- a/src/main/java/dev/brus/msar2rw/App.java
+++ b/src/main/java/dev/brus/msar2rw/App.java
@@ -252,9 +252,9 @@ public class App {
       for (int i = activityEntries.size() - 1; i >= 0; i--) {
          ActivityEntry activityEntry = activityEntries.get(i);
 
-         // the shares to remove should be the ones bought before the sell (in the negativeActivityEntry)
+         // the shares to remove should be the ones bought before (or the same day) the sell (in the negativeActivityEntry)
          // by comparing the activity date with the sell date allows to skip the ones coming after the sell itself
-         if (activityEntry.getShares().compareTo(BigDecimal.ZERO) > 0 && activityEntry.getDate().compareTo(negativeActivityEntry.getDate()) < 0) {
+         if (activityEntry.getShares().compareTo(BigDecimal.ZERO) > 0 && activityEntry.getDate().compareTo(negativeActivityEntry.getDate()) <= 0) {
             if (activityEntry.getShares().compareTo(decrementingShares) >= 0) {
                decrementingReportEntries.add(new ReportEntry().setStartDate(activityEntry.getDate()).
                   setEndDate(negativeActivityEntry.getDate()).

--- a/src/main/java/dev/brus/msar2rw/App.java
+++ b/src/main/java/dev/brus/msar2rw/App.java
@@ -252,7 +252,9 @@ public class App {
       for (int i = activityEntries.size() - 1; i >= 0; i--) {
          ActivityEntry activityEntry = activityEntries.get(i);
 
-         if (activityEntry.getShares().compareTo(BigDecimal.ZERO) > 0) {
+         // the shares to remove should be the ones bought before the sell (in the negativeActivityEntry)
+         // by comparing the activity date with the sell date allows to skip the ones coming after the sell itself
+         if (activityEntry.getShares().compareTo(BigDecimal.ZERO) > 0 && activityEntry.getDate().compareTo(negativeActivityEntry.getDate()) < 0) {
             if (activityEntry.getShares().compareTo(decrementingShares) >= 0) {
                decrementingReportEntries.add(new ReportEntry().setStartDate(activityEntry.getDate()).
                   setEndDate(negativeActivityEntry.getDate()).


### PR DESCRIPTION
When it comes to a sell and we need to decrease the shares going through the "aggregate" entries, we should consider only the entries coming before the sell not the ones coming later.