### PR TITLE
Fixed the way to process the holding days

### DIFF
--- a/src/main/java/dev/brus/msar2rw/App.java
+++ b/src/main/java/dev/brus/msar2rw/App.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import com.google.gson.JsonArray;
@@ -226,7 +227,7 @@ public class App {
       rwEntryFields.add(endValue.toString());
 
       //10 - Giorni IVAFE- IC
-      int days = (int)Math.ceil((entry.getEndDate().getTime() - entry.getStartDate().getTime()) / 86400000d) + 1;
+      long days = TimeUnit.MILLISECONDS.toDays(entry.getEndDate().getTime() - entry.getStartDate().getTime()) + 1;
       rwEntryFields.add(String.valueOf(days));
 
       //14 - Codice


### PR DESCRIPTION
It seems the current way to calculate the holding days provides a wrong result missing a day. It doesn't happen in all cases but ... most of them. This PR provides a way which should not rely on the current division but using the `TimeUnit` class utility methods.